### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -5,7 +5,7 @@
 #######################################
 # Library (KEYWORD3)
 #######################################
-smeBle	     KEYWORD3
+smeBle	KEYWORD3
 
 #######################################
 # Datatypes (KEYWORD1)
@@ -14,11 +14,11 @@ smeBle	     KEYWORD3
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-begin	            KEYWORD2
-read                KEYWORD2
-available           KEYWORD2
-write               KEYWORD2
-writeChar           KEYWORD2
+begin	KEYWORD2
+read	KEYWORD2
+available	KEYWORD2
+write	KEYWORD2
+writeChar	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords